### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/src/about/views.py
+++ b/src/about/views.py
@@ -1,11 +1,15 @@
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from . import ConsentHttpRequest
 
 
 def set_consent(request: ConsentHttpRequest) -> HttpResponse:
-    response = HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))
+    referer = request.META.get("HTTP_REFERER", "/")
+    if not url_has_allowed_host_and_scheme(referer, allowed_hosts=None):
+        referer = "/"
+    response = HttpResponseRedirect(referer)
     if request.method == "POST":
         accepted = request.POST.get(settings.COOKIE_CONSENT_COOKIE_NAME) == "1"
         if accepted:


### PR DESCRIPTION
Potential fix for [https://github.com/comicagg/comicagg/security/code-scanning/1](https://github.com/comicagg/comicagg/security/code-scanning/1)

To fix the problem, we need to ensure that the URL redirection is only performed to trusted URLs. We can use Django's `url_has_allowed_host_and_scheme` function to validate the `HTTP_REFERER` value before performing the redirection. This function checks that the URL is safe to redirect to by ensuring it has an allowed host and scheme.

We will modify the code in `src/about/views.py` to use `url_has_allowed_host_and_scheme` to validate the `HTTP_REFERER` value. If the value is not valid, we will redirect to the home page (`'/'`) instead.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
